### PR TITLE
feat: Allow users to navigate to attachments from payment form and co…

### DIFF
--- a/src/components/visa-application/PaymentForm.tsx
+++ b/src/components/visa-application/PaymentForm.tsx
@@ -91,8 +91,9 @@ export default function PaymentForm() {
         mutationFn: (data: { formId: string }) => visaApi.createStripeSession(data),
         onSuccess: (data) => {
             // Redirect to Stripe checkout page
-            if (data && data.session_url) {
-                window.location.href = data.session_url;
+            console.log('Stripe session created:', data);
+            if (data?.data && data?.data?.session_url) {
+                window.location.href = data?.data?.session_url;
             } else {
                 setPaymentStatus('error');
                 setPaymentError('Failed to create payment session');
@@ -297,6 +298,13 @@ export default function PaymentForm() {
                     onClick={() => setCurrentStep('review')}
                 >
                     Review Application
+                </Button>
+
+                <Button
+                    variant="default"
+                    onClick={() => setCurrentStep('attachments')}
+                >
+                    Attach Documents
                 </Button>
             </div>
         </div>

--- a/src/providers/apiIntegration.tsx
+++ b/src/providers/apiIntegration.tsx
@@ -14,12 +14,12 @@ export function integrateApiDataIntoFormState(apiData: VisaApplication) {
 
     if (apiData.lastExitUrl === 'payment') {
         currentStep = 'payment';
+    } else if (apiData.lastExitUrl === 'attachments') {
+        currentStep = 'attachments';
     } else if (apiData.paymentStatus === 'paid') {
         currentStep = 'confirmation';
     } else if (apiData.applicationStatus === 'submitted') {
         currentStep = 'payment';
-    } else if (apiData.lastExitUrl === 'attachments') {
-        currentStep = 'attachments';
     } else if (apiData.lastExitUrl === 'review') {
         currentStep = 'review';
     } else if (apiData.lastExitUrl === 'additional-applicants') {


### PR DESCRIPTION
…ntinue from attachments

This commit introduces the ability for users to navigate to the attachments form from the payment form and continue their application from the attachments step. Key changes include:

- Added a button to the PaymentForm that allows users to navigate to the attachments form.
- Updated the apiIntegration to correctly set the current step to 'attachments' when the lastExitUrl is 'attachments'.
- Added console log for stripe session data.